### PR TITLE
Change 'tsuyoshiushio/durableexternalscaler' to 'kedacore/keda-scaler-durable-functions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ KEDA Durable Functions Scaler works as a gRPC server of the [External Scaler Sup
 Currently, KEDA Durable Scaler can't make functions scale down to zero. Minimum pod number is one. Durable Scaler need to send data to control/worker queue. For achieve this behavior, we need to separate the HTTP and non-HTTP deployments. However, the feature seems not working. We need to wait until this issue is fixed. 
 
 * [Add configuration for enabling only HTTP or only non-HTTP functions #4412](https://github.com/Azure/azure-functions-host/issues/4412)
-* [Pods doesn't scale in to zero #17](https://github.com/microsoft/keda-durable-scaler/issues/17)
+* [Pods doesn't scale in to zero #17](https://github.com/kedacore/keda-scaler-durable-functions/issues/17)
 
 ## Getting Started & Documentation
 

--- a/deploy/build_push_image.sh
+++ b/deploy/build_push_image.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 cd ..
-docker build . -t tsuyoshiushio/durableexternalscaler:latest -t tsuyoshiushio/durableexternalscaler:0.1
-docker push tsuyoshiushio/durableexternalscaler
+docker build . -t kedacore/keda-scaler-durable-functions:latest -t kedacore/keda-scaler-durable-functions:0.1
+docker push kedacore/keda-scaler-durable-functions
 cd deploy

--- a/deploy/deployment.yml
+++ b/deploy/deployment.yml
@@ -52,7 +52,7 @@ spec:
     spec:
       serviceAccountName: keda-durable-scaler
       containers:
-      - image: tsuyoshiushio/durableexternalscaler:latest
+      - image: kedacore/keda-scaler-durable-functions:latest
         name: scaler
         ports:
           - containerPort: 5000

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -66,15 +66,15 @@ You can refer [Getting Started](getting-started.md) to create and configure cert
 
 For reading this code, there is several important files are there. 
 
-#### [ExternalScalerService](https://github.com/microsoft/keda-durable-scaler/blob/master/src/Keda.Durable.Scaler.Server/Services/ExternalScalerService.cs)
+#### [ExternalScalerService](https://github.com/kedacore/keda-scaler-durable-functions/blob/master/src/Keda.Durable.Scaler.Server/Services/ExternalScalerService.cs)
 
 Core logic of the scaling. This class implement scaler logic of this server. It uses, [DurableTask.DisconnectPerformanceMonitor](https://github.com/Azure/durabletask/blob/master/src/DurableTask.AzureStorage/Monitoring/DisconnectedPerformanceMonitor.cs#L89) for getting analytics data nad telemetry. 
 
-#### [externalscaler.proto](https://github.com/microsoft/keda-durable-scaler/blob/master/src/Keda.Durable.Scaler.Server/Protos/externalscaler.proto)
+#### [externalscaler.proto](https://github.com/kedacore/keda-scaler-durable-functions/blob/master/src/Keda.Durable.Scaler.Server/Protos/externalscaler.proto)
 
 Protocol buffer of the [External Scaler Support for KEDA](https://github.com/kedacore/keda/pull/294). Usually, you might need to generate code from this buffer. It is automatically done by [gRPC services with ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/grpc/aspnetcore?view=aspnetcore-3.0&tabs=visual-studio). You can see the generated file under the obj directory, however, you don't need commit these files to the repo. 
 
-#### [Startup.cs](https://github.com/microsoft/keda-durable-scaler/blob/master/src/Keda.Durable.Scaler.Server/Startup.cs#L21)
+#### [Startup.cs](https://github.com/kedacore/keda-scaler-durable-functions/blob/master/src/Keda.Durable.Scaler.Server/Startup.cs#L21)
 
 It contains DI configration for the server, it also include Enviornment Variables configration for the Server. 
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ $ kubectl apply -f deploy/
 Clone the KEDA Durable Scaler repo
 
 ```bash
-$ git clone git@github.com:microsoft/keda-durable-scaler.git
+$ git clone git@github.com:kedacore/keda-scaler-durable-functions.git
 $ cd keda-durable-scaler
 ```
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,7 +26,7 @@ spec:
     spec:
       serviceAccountName: keda-durable-scaler
       containers:
-      - image: tsuyoshiushio/durableexternalscaler:latest
+      - image: kedacore/keda-scaler-durable-functions:latest
         name: scaler
         ports:
           - containerPort: 5000

--- a/examples/durable-keda/build_push_image.sh
+++ b/examples/durable-keda/build_push_image.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker build . -t tsuyoshiushio/durable-keda:latest -t tsuyoshiushio/durable-keda:0.1
-docker push tsuyoshiushio/durable-keda
+docker build . -t kedacore/durable-keda:latest -t kedacore/durable-keda:0.1
+docker push kedacore/durable-keda

--- a/examples/durable-keda/deployone.yml
+++ b/examples/durable-keda/deployone.yml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: durable-keda
-        image: tsuyoshiushio/durable-keda:latest
+        image: kedacore/durable-keda:latest
         ports:
         - containerPort: 80
         env:


### PR DESCRIPTION
- Change 'tsuyoshiushio/durableexternalscaler' to 'kedacore/keda-scaler-durable-functions'
- Use new repo name in docs

Relates to #8